### PR TITLE
refactor: Update GitHub username from erickshaffer to eshaffer321

### DIFF
--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/erickshaffer/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
 )
 
 // ValidatorConfig holds configuration for the validator
@@ -79,7 +79,7 @@ func main() {
 func parseFlags() *ValidatorConfig {
 	config := &ValidatorConfig{}
 
-	flag.StringVar(&config.PythonPath, "python", "/Users/erickshaffer/code/monarchmoney", "Path to Python client")
+	flag.StringVar(&config.PythonPath, "python", "/Users/eshaffer321/code/monarchmoney", "Path to Python client")
 	flag.StringVar(&config.GoToken, "go-token", os.Getenv("MONARCH_TOKEN"), "Token for Go client")
 	flag.StringVar(&config.PythonToken, "python-token", os.Getenv("MONARCH_TOKEN"), "Token for Python client")
 	flag.StringVar(&config.OutputDir, "output", "./validation_results", "Output directory for results")

--- a/examples/full_example.go
+++ b/examples/full_example.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/erickshaffer/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
 )
 
 // This example demonstrates all available services and their methods

--- a/examples/sentry/main.go
+++ b/examples/sentry/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/erickshaffer/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
 	"github.com/getsentry/sentry-go"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/erickshaffer/monarchmoney-go
+module github.com/eshaffer321/monarchmoney-go
 
 go 1.21
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/erickshaffer/monarchmoney-go/internal/types"
+	"github.com/eshaffer321/monarchmoney-go/internal/types"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )

--- a/internal/transport/graphql.go
+++ b/internal/transport/graphql.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/erickshaffer/monarchmoney-go/internal/types"
+	"github.com/eshaffer321/monarchmoney-go/internal/types"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
 )

--- a/pkg/monarch/accounts_balances_test.go
+++ b/pkg/monarch/accounts_balances_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/erickshaffer/monarchmoney-go/internal/graphql"
+	"github.com/eshaffer321/monarchmoney-go/internal/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/pkg/monarch/accounts_test.go
+++ b/pkg/monarch/accounts_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/erickshaffer/monarchmoney-go/internal/graphql"
-	internalTypes "github.com/erickshaffer/monarchmoney-go/internal/types"
+	"github.com/eshaffer321/monarchmoney-go/internal/graphql"
+	internalTypes "github.com/eshaffer321/monarchmoney-go/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/pkg/monarch/auth.go
+++ b/pkg/monarch/auth.go
@@ -3,8 +3,8 @@ package monarch
 import (
 	"context"
 
-	"github.com/erickshaffer/monarchmoney-go/internal/auth"
-	internalTypes "github.com/erickshaffer/monarchmoney-go/internal/types"
+	"github.com/eshaffer321/monarchmoney-go/internal/auth"
+	internalTypes "github.com/eshaffer321/monarchmoney-go/internal/types"
 )
 
 // authService implements the AuthService interface

--- a/pkg/monarch/budgets_test.go
+++ b/pkg/monarch/budgets_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/erickshaffer/monarchmoney-go/internal/graphql"
+	"github.com/eshaffer321/monarchmoney-go/internal/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/pkg/monarch/cashflow_test.go
+++ b/pkg/monarch/cashflow_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/erickshaffer/monarchmoney-go/internal/graphql"
+	"github.com/eshaffer321/monarchmoney-go/internal/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/pkg/monarch/client.go
+++ b/pkg/monarch/client.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/erickshaffer/monarchmoney-go/internal/graphql"
-	"github.com/erickshaffer/monarchmoney-go/internal/transport"
-	internalTypes "github.com/erickshaffer/monarchmoney-go/internal/types"
+	"github.com/eshaffer321/monarchmoney-go/internal/graphql"
+	"github.com/eshaffer321/monarchmoney-go/internal/transport"
+	internalTypes "github.com/eshaffer321/monarchmoney-go/internal/types"
 	"github.com/getsentry/sentry-go"
 )
 

--- a/pkg/monarch/institutions_test.go
+++ b/pkg/monarch/institutions_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/erickshaffer/monarchmoney-go/internal/graphql"
+	"github.com/eshaffer321/monarchmoney-go/internal/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/pkg/monarch/recurring_test.go
+++ b/pkg/monarch/recurring_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/erickshaffer/monarchmoney-go/internal/graphql"
+	"github.com/eshaffer321/monarchmoney-go/internal/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/pkg/monarch/tags_test.go
+++ b/pkg/monarch/tags_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/erickshaffer/monarchmoney-go/internal/graphql"
+	"github.com/eshaffer321/monarchmoney-go/internal/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/pkg/monarch/transactions_categories_test.go
+++ b/pkg/monarch/transactions_categories_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/erickshaffer/monarchmoney-go/internal/graphql"
+	"github.com/eshaffer321/monarchmoney-go/internal/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/pkg/monarch/transactions_splits_test.go
+++ b/pkg/monarch/transactions_splits_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/erickshaffer/monarchmoney-go/internal/graphql"
+	"github.com/eshaffer321/monarchmoney-go/internal/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/pkg/monarch/transactions_test.go
+++ b/pkg/monarch/transactions_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/erickshaffer/monarchmoney-go/internal/graphql"
+	"github.com/eshaffer321/monarchmoney-go/internal/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
## Summary
- Updates all module references and import paths from `github.com/erickshaffer/monarchmoney-go` to `github.com/eshaffer321/monarchmoney-go`
- Changes reflect the new GitHub username across the entire codebase

## Changes Made
- Updated `go.mod` module declaration
- Updated all import statements in Go files
- Updated path references in validator configuration

## Test Plan
- [x] All existing tests pass
- [x] Module builds successfully
- [ ] CI checks pass