### PR TITLE
fix: Handle both single object and array error formats in UpdateSplits

### DIFF
--- a/pkg/monarch/transactions.go
+++ b/pkg/monarch/transactions.go
@@ -328,7 +328,7 @@ func (s *transactionService) UpdateSplits(ctx context.Context, transactionID str
 	}
 
 	// Handle errors field which can be either a single object or an array
-	if result.UpdateTransactionSplit.Errors != nil && len(result.UpdateTransactionSplit.Errors) > 0 {
+	if len(result.UpdateTransactionSplit.Errors) > 0 {
 		// Skip if it's an empty array: []
 		if string(result.UpdateTransactionSplit.Errors) == "[]" {
 			return nil

--- a/pkg/monarch/transactions_splits_test.go
+++ b/pkg/monarch/transactions_splits_test.go
@@ -198,3 +198,208 @@ func TestTransactionService_GetSummary_EmptyResult(t *testing.T) {
 	
 	mockTransport.AssertExpectations(t)
 }
+
+func TestTransactionService_UpdateSplits_ErrorHandling_SingleObject(t *testing.T) {
+	// Setup
+	mockTransport := new(MockTransport)
+	client := &Client{
+		transport:   mockTransport,
+		queryLoader: graphql.NewQueryLoader(),
+		options:     &ClientOptions{},
+		baseURL:     "https://api.test.com",
+	}
+	client.initServices()
+
+	// Mock response with a single error object (not an array)
+	// This reproduces the actual API response that causes the unmarshal error
+	response := `{
+		"updateTransactionSplit": {
+			"transaction": null,
+			"errors": {
+				"message": "Transaction already has splits",
+				"code": "TRANSACTION_HAS_SPLITS",
+				"fieldErrors": []
+			}
+		}
+	}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(response, nil)
+
+	splits := []*TransactionSplit{
+		{
+			Amount:     30.00,
+			CategoryID: "cat-1",
+		},
+		{
+			Amount:     30.63,
+			CategoryID: "cat-2",
+		},
+	}
+
+	err := client.Transactions.UpdateSplits(context.Background(), "220449306160236661", splits)
+	
+	// Should get a proper error, not an unmarshal error
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Transaction already has splits")
+	
+	mockTransport.AssertExpectations(t)
+}
+
+func TestTransactionService_UpdateSplits_ErrorHandling_ValidationError(t *testing.T) {
+	// Setup
+	mockTransport := new(MockTransport)
+	client := &Client{
+		transport:   mockTransport,
+		queryLoader: graphql.NewQueryLoader(),
+		options:     &ClientOptions{},
+		baseURL:     "https://api.test.com",
+	}
+	client.initServices()
+
+	// Mock response with validation error details
+	response := `{
+		"updateTransactionSplit": {
+			"transaction": null,
+			"errors": {
+				"message": "Validation failed",
+				"code": "VALIDATION_ERROR",
+				"fieldErrors": [
+					{
+						"field": "amount",
+						"messages": ["Split amounts must equal transaction amount"]
+					}
+				]
+			}
+		}
+	}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(response, nil)
+
+	splits := []*TransactionSplit{
+		{
+			Amount:     30.00,
+			CategoryID: "cat-1",
+		},
+		{
+			Amount:     20.00,
+			CategoryID: "cat-2",
+		},
+	}
+
+	err := client.Transactions.UpdateSplits(context.Background(), "test-txn-123", splits)
+	
+	// Should get a proper error with field details
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Validation failed")
+	assert.Contains(t, err.Error(), "amount: Split amounts must equal transaction amount")
+	
+	mockTransport.AssertExpectations(t)
+}
+
+func TestTransactionService_UpdateSplits_ErrorHandling_ArrayFormat(t *testing.T) {
+	// Setup
+	mockTransport := new(MockTransport)
+	client := &Client{
+		transport:   mockTransport,
+		queryLoader: graphql.NewQueryLoader(),
+		options:     &ClientOptions{},
+		baseURL:     "https://api.test.com",
+	}
+	client.initServices()
+
+	// Mock response with errors as an array (standard GraphQL format)
+	response := `{
+		"updateTransactionSplit": {
+			"transaction": null,
+			"errors": [
+				{
+					"message": "Invalid split configuration",
+					"code": "INVALID_SPLIT",
+					"fieldErrors": []
+				}
+			]
+		}
+	}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(response, nil)
+
+	splits := []*TransactionSplit{
+		{
+			Amount:     60.63,
+			CategoryID: "cat-1",
+		},
+	}
+
+	err := client.Transactions.UpdateSplits(context.Background(), "test-txn-123", splits)
+	
+	// Should handle array format correctly
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid split configuration")
+	
+	mockTransport.AssertExpectations(t)
+}
+
+func TestTransactionService_UpdateSplits_Success_EmptyErrorArray(t *testing.T) {
+	// Setup
+	mockTransport := new(MockTransport)
+	client := &Client{
+		transport:   mockTransport,
+		queryLoader: graphql.NewQueryLoader(),
+		options:     &ClientOptions{},
+		baseURL:     "https://api.test.com",
+	}
+	client.initServices()
+
+	// Mock successful response with empty errors array
+	response := `{
+		"updateTransactionSplit": {
+			"transaction": {
+				"id": "test-txn-123",
+				"hasSplitTransactions": true,
+				"splitTransactions": [
+					{
+						"id": "split-1",
+						"amount": 30.00,
+						"category": {
+							"id": "cat-1",
+							"name": "Groceries"
+						}
+					},
+					{
+						"id": "split-2",
+						"amount": 30.63,
+						"category": {
+							"id": "cat-2",
+							"name": "Shopping"
+						}
+					}
+				]
+			},
+			"errors": []
+		}
+	}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(response, nil)
+
+	splits := []*TransactionSplit{
+		{
+			Amount:     30.00,
+			CategoryID: "cat-1",
+		},
+		{
+			Amount:     30.63,
+			CategoryID: "cat-2",
+		},
+	}
+
+	err := client.Transactions.UpdateSplits(context.Background(), "test-txn-123", splits)
+	
+	// Should succeed with empty errors array
+	assert.NoError(t, err)
+	
+	mockTransport.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary
- Fixed error handling in `UpdateSplits` to support both single object and array error formats from the Monarch API
- Added comprehensive test coverage for all error scenarios
- Includes field-level error details in error messages for better debugging

## Problem
The Monarch API returns errors in different formats:
- Sometimes as a single error object: `"errors": { "message": "...", "code": "..." }`
- Sometimes as an array: `"errors": [{ "message": "...", "code": "..." }]`

This was causing unmarshal errors when the API returned a single error object.

## Solution
- Changed error field to use `json.RawMessage` to handle both formats dynamically
- Try unmarshaling as single object first, then as array if that fails
- Include field-level validation errors in the error message when present
- Added 4 new test cases covering all error scenarios

## Test Plan
- [x] Added test for single error object format
- [x] Added test for array error format  
- [x] Added test for validation errors with field details
- [x] Added test for successful response with empty error array
- [x] All existing tests still pass
- [x] No secrets or credentials in changes