### PR TITLE
feat: Add Goals structure to MCP server budget response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,10 @@ TODO.md
 # Integration test outputs
 test/integration/*.out
 test/integration/*.log
+
+# MCP server binary
+mcp-monarch
+cmd/mcp-server/mcp-monarch
+
+# Test files
+test_*.go

--- a/cmd/mcp-server/tools.go
+++ b/cmd/mcp-server/tools.go
@@ -30,9 +30,21 @@ type BudgetEntry struct {
 	Percentage     float64 `json:"percentage" jsonschema:"Percentage of budget spent"`
 }
 
+type GoalEntry struct {
+	ID                 string  `json:"id" jsonschema:"Goal ID"`
+	Name               string  `json:"name" jsonschema:"Goal name"`
+	CurrentBalance     float64 `json:"currentBalance" jsonschema:"Current balance toward goal"`
+	TargetBalance      float64 `json:"targetBalance" jsonschema:"Target balance for goal"`
+	Type               string  `json:"type" jsonschema:"Goal type"`
+	PaceType           string  `json:"paceType,omitempty" jsonschema:"Pace status (on_track, behind, etc.)"`
+	OriginAccount      string  `json:"originAccount,omitempty" jsonschema:"Origin account name"`
+	DestinationAccount string  `json:"destinationAccount,omitempty" jsonschema:"Destination account name"`
+}
+
 type GetBudgetOutput struct {
 	Month   string        `json:"month" jsonschema:"Month of the budget data"`
 	Budgets []BudgetEntry `json:"budgets" jsonschema:"List of budget entries for each category"`
+	Goals   []GoalEntry   `json:"goals,omitempty" jsonschema:"List of goals associated with this budget"`
 }
 
 func (t *monarchTools) GetBudget(ctx context.Context, req *mcp.CallToolRequest, input GetBudgetInput) (*mcp.CallToolResult, GetBudgetOutput, error) {
@@ -72,6 +84,7 @@ func (t *monarchTools) GetBudget(ctx context.Context, req *mcp.CallToolRequest, 
 	return nil, GetBudgetOutput{
 		Month:   input.Month,
 		Budgets: entries,
+		Goals:   nil, // Goals not currently supported in budget query
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
Prepares the MCP server to support goals data in budget queries by adding the necessary data structures.

## Changes
- ✅ Add `GoalEntry` type with fields for goal metadata (ID, name, balances, type, accounts)
- ✅ Add `Goals` field to `GetBudgetOutput` response structure  
- ✅ Update `.gitignore` to exclude MCP binary artifacts and test files

## Current State
Currently returns `nil` for goals with a comment explaining that goals require a separate API query. This sets up the infrastructure for future goals support without breaking existing functionality.

## Next Steps
The Goals API integration will be completed in a follow-up PR once the correct GraphQL query structure is determined from the Monarch Money API. Initial investigation shows that `budgetData.goalsV2` doesn't exist in the API schema - goals likely need to be queried separately.

## Testing
- [x] MCP server builds successfully
- [x] MCP server runs and returns budget data (with empty goals array)
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)