### PR TITLE
chore: Improve repository cleanup and artifact management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,12 @@ clean:
 	@echo "$(YELLOW)Cleaning build artifacts...$(NC)"
 	@rm -rf $(BINARY_DIR)
 	@rm -f $(COVERAGE_FILE) $(COVERAGE_HTML)
+	@rm -f coverage.txt
+	@rm -f mcp-monarch
+	@rm -f cmd/mcp-server/mcp-monarch
+	@rm -f test_*.go
+	@rm -f security-report.json
+	@find . -name "*.bak" -type f -delete
 	@echo "$(GREEN)Clean complete$(NC)"
 
 ## deps: Download dependencies

--- a/cmd/mcp-server/.gitignore
+++ b/cmd/mcp-server/.gitignore
@@ -1,1 +1,0 @@
-monarch-mcp-server


### PR DESCRIPTION
## Summary

This PR improves the `make clean` target to properly remove ALL build artifacts, not just the `bin/` directory. It also removes a redundant `.gitignore` file in the mcp-server directory.

## Changes Made

### Enhanced Makefile clean target
- ✅ Added removal of `coverage.txt` (root coverage file)
- ✅ Added removal of `mcp-monarch` binaries (root and `cmd/mcp-server/`)
- ✅ Added removal of `test_*.go` files (ad-hoc test files)
- ✅ Added removal of `security-report.json` (from `make security`)
- ✅ Added removal of `*.bak` files (backup files)

### Cleanup
- ✅ Removed redundant `cmd/mcp-server/.gitignore` 
  - Root `.gitignore` already covers `mcp-monarch` binary
  - Subdirectory `.gitignore` had wrong binary name (`monarch-mcp-server` vs `mcp-monarch`)

## Why This Matters

**Before this PR:** Running `make clean` would only remove the `bin/` directory and `coverage.out`/`coverage.html` files, leaving behind:
- `coverage.txt` (36KB)
- `mcp-monarch` binary (11MB)
- `test_*.go` files
- `*.bak` backup files
- `security-report.json`

**After this PR:** `make clean` removes ALL artifacts consistently.

## Testing

- ✅ All tests pass (51/51)
- ✅ `make clean` successfully removes all artifacts
- ✅ Verified artifacts are properly gitignored (not committed)

## Notes

This addresses the issue where `make clean` didn't remove `coverage.txt` and other artifacts that were left in the working directory. The `.gitignore` was already correctly configured to ignore these files - we just needed the `clean` target to remove them properly.