### PR TITLE
feat(holdings): add holdings management and investments account support

### DIFF
--- a/internal/graphql/queries/accounts/create_holding.graphql
+++ b/internal/graphql/queries/accounts/create_holding.graphql
@@ -1,0 +1,12 @@
+mutation Common_CreateManualHolding($input: CreateManualHoldingInput!) {
+  createManualHolding(input: $input) {
+    holding {
+      id
+      ticker
+    }
+    errors {
+      message
+      code
+    }
+  }
+}

--- a/internal/graphql/queries/accounts/create_investments_account.graphql
+++ b/internal/graphql/queries/accounts/create_investments_account.graphql
@@ -1,0 +1,24 @@
+mutation Common_CreateManualInvestmentsAccount($input: CreateManualInvestmentsAccountInput!) {
+  createManualInvestmentsAccount(input: $input) {
+    account {
+      id
+      __typename
+    }
+    errors {
+      ...PayloadErrorFields
+      __typename
+    }
+    __typename
+  }
+}
+
+fragment PayloadErrorFields on PayloadError {
+  fieldErrors {
+    field
+    messages
+    __typename
+  }
+  message
+  code
+  __typename
+}

--- a/internal/graphql/queries/accounts/delete_holding.graphql
+++ b/internal/graphql/queries/accounts/delete_holding.graphql
@@ -1,0 +1,9 @@
+mutation Common_DeleteHolding($id: ID!) {
+  deleteHolding(id: $id) {
+    deleted
+    errors {
+      message
+      code
+    }
+  }
+}

--- a/internal/graphql/queries/accounts/holdings.graphql
+++ b/internal/graphql/queries/accounts/holdings.graphql
@@ -1,18 +1,27 @@
-query GetAccountHoldings($accountId: UUID!) {
-  account(id: $accountId) {
-    id
-    holdings {
+query Web_GetHoldings($input: PortfolioInput) {
+  portfolio(input: $input) {
+    aggregateHoldings {
       edges {
         node {
           id
-          symbol
           quantity
-          price
-          value
-          costBasis
-          updatedAt
-          holding {
+          basis
+          totalValue
+          holdings {
+            id
+            type
             name
+            ticker
+            closingPrice
+            isManual
+          }
+          security {
+            id
+            name
+            type
+            ticker
+            currentPrice
+            currentPriceUpdatedAt
           }
         }
       }

--- a/internal/graphql/queries/accounts/search_securities.graphql
+++ b/internal/graphql/queries/accounts/search_securities.graphql
@@ -1,0 +1,12 @@
+query SecuritySearch($search: String!, $limit: Int, $orderByPopularity: Boolean) {
+  securities(
+    search: $search
+    limit: $limit
+    orderByPopularity: $orderByPopularity
+  ) {
+    id
+    name
+    ticker
+    currentPrice
+  }
+}

--- a/internal/graphql/queries/accounts/update_holding.graphql
+++ b/internal/graphql/queries/accounts/update_holding.graphql
@@ -1,0 +1,15 @@
+mutation Common_UpdateHoldingMutation($input: UpdateHoldingInput!) {
+  updateHolding(input: $input) {
+    holding {
+      id
+      quantity
+      __typename
+    }
+    errors {
+      message
+      code
+      __typename
+    }
+    __typename
+  }
+}

--- a/pkg/monarch/accounts.go
+++ b/pkg/monarch/accounts.go
@@ -513,6 +513,14 @@ func (s *accountService) GetHoldings(ctx context.Context, accountID string) ([]*
 			if name == "" {
 				name = edge.Node.Holdings[0].Name
 			}
+			// Fall back to sub-holding closingPrice if security price is zero
+			if price == 0 {
+				price = edge.Node.Holdings[0].Price
+			}
+		}
+		// Derive from totalValue/quantity as last resort
+		if price == 0 && edge.Node.Quantity > 0 {
+			price = edge.Node.Value / edge.Node.Quantity
 		}
 		holdings = append(holdings, &Holding{
 			ID:        holdingID,

--- a/pkg/monarch/accounts.go
+++ b/pkg/monarch/accounts.go
@@ -94,6 +94,59 @@ func (s *accountService) Create(ctx context.Context, params *CreateAccountParams
 	return s.Get(ctx, result.CreateManualAccount.Account.ID)
 }
 
+// CreateInvestmentsAccount creates a manual investments account with initial holdings.
+// Uses the Common_CreateManualInvestmentsAccount mutation which creates the account
+// and adds holdings in a single call.
+func (s *accountService) CreateInvestmentsAccount(ctx context.Context, params *CreateInvestmentsAccountParams) (*Account, error) {
+	query := s.client.loadQuery("accounts/create_investments_account.graphql")
+
+	holdings := make([]map[string]interface{}, len(params.InitialHoldings))
+	for i, h := range params.InitialHoldings {
+		holdings[i] = map[string]interface{}{
+			"securityId": h.SecurityID,
+			"quantity":   h.Quantity,
+		}
+	}
+
+	variables := map[string]interface{}{
+		"input": map[string]interface{}{
+			"name":                            params.Name,
+			"subtype":                         params.Subtype,
+			"manualInvestmentsTrackingMethod": params.ManualInvestmentsTrackingMethod,
+			"initialHoldings":                 holdings,
+		},
+	}
+
+	var result struct {
+		CreateManualInvestmentsAccount struct {
+			Account *struct {
+				ID string `json:"id"`
+			} `json:"account"`
+			Errors []struct {
+				Message string `json:"message"`
+				Code    string `json:"code"`
+			} `json:"errors"`
+		} `json:"createManualInvestmentsAccount"`
+	}
+
+	if err := s.client.executeGraphQL(ctx, query, variables, &result); err != nil {
+		return nil, errors.Wrap(err, "failed to create investments account")
+	}
+
+	if len(result.CreateManualInvestmentsAccount.Errors) > 0 {
+		return nil, &Error{
+			Code:    result.CreateManualInvestmentsAccount.Errors[0].Code,
+			Message: result.CreateManualInvestmentsAccount.Errors[0].Message,
+		}
+	}
+
+	if result.CreateManualInvestmentsAccount.Account == nil {
+		return nil, errors.New("no account returned from creation")
+	}
+
+	return s.Get(ctx, result.CreateManualInvestmentsAccount.Account.ID)
+}
+
 // Update updates an existing account
 func (s *accountService) Update(ctx context.Context, accountID string, params *UpdateAccountParams) (*Account, error) {
 	query := s.client.loadQuery("accounts/update.graphql")
@@ -400,34 +453,45 @@ func (s *accountService) GetHistory(ctx context.Context, accountID string) (*Acc
 	return history, nil
 }
 
-// GetHoldings retrieves investment holdings for an account
+// GetHoldings retrieves investment holdings for an account using the portfolio query.
 func (s *accountService) GetHoldings(ctx context.Context, accountID string) ([]*Holding, error) {
 	query := s.client.loadQuery("accounts/holdings.graphql")
 
+	now := time.Now().Format("2006-01-02")
 	variables := map[string]interface{}{
-		"accountId": accountID,
+		"input": map[string]interface{}{
+			"accountIds":            []string{accountID},
+			"endDate":               now,
+			"startDate":             now,
+			"includeHiddenHoldings": true,
+		},
 	}
 
 	var result struct {
-		Account struct {
-			ID       string `json:"id"`
-			Holdings struct {
+		Portfolio struct {
+			AggregateHoldings struct {
 				Edges []struct {
 					Node struct {
-						ID        string    `json:"id"`
-						Symbol    string    `json:"symbol"`
-						Quantity  float64   `json:"quantity"`
-						Price     float64   `json:"price"`
-						Value     float64   `json:"value"`
-						CostBasis float64   `json:"costBasis"`
-						UpdatedAt time.Time `json:"updatedAt"`
-						Holding   struct {
-							Name string `json:"name"`
-						} `json:"holding"`
+						ID       string  `json:"id"`
+						Quantity float64 `json:"quantity"`
+						Basis    float64 `json:"basis"`
+						Value    float64 `json:"totalValue"`
+						Holdings []struct {
+							ID     string  `json:"id"`
+							Name   string  `json:"name"`
+							Ticker string  `json:"ticker"`
+							Price  float64 `json:"closingPrice"`
+						} `json:"holdings"`
+						Security struct {
+							ID     string  `json:"id"`
+							Name   string  `json:"name"`
+							Ticker string  `json:"ticker"`
+							Price  float64 `json:"currentPrice"`
+						} `json:"security"`
 					} `json:"node"`
 				} `json:"edges"`
-			} `json:"holdings"`
-		} `json:"account"`
+			} `json:"aggregateHoldings"`
+		} `json:"portfolio"`
 	}
 
 	if err := s.client.executeGraphQL(ctx, query, variables, &result); err != nil {
@@ -435,17 +499,30 @@ func (s *accountService) GetHoldings(ctx context.Context, accountID string) ([]*
 	}
 
 	var holdings []*Holding
-	for _, edge := range result.Account.Holdings.Edges {
+	for _, edge := range result.Portfolio.AggregateHoldings.Edges {
+		ticker := edge.Node.Security.Ticker
+		name := edge.Node.Security.Name
+		price := edge.Node.Security.Price
+		// Use first sub-holding ID as the holding ID
+		holdingID := edge.Node.ID
+		if len(edge.Node.Holdings) > 0 {
+			holdingID = edge.Node.Holdings[0].ID
+			if ticker == "" {
+				ticker = edge.Node.Holdings[0].Ticker
+			}
+			if name == "" {
+				name = edge.Node.Holdings[0].Name
+			}
+		}
 		holdings = append(holdings, &Holding{
-			ID:        edge.Node.ID,
+			ID:        holdingID,
 			AccountID: accountID,
-			Symbol:    edge.Node.Symbol,
-			Name:      edge.Node.Holding.Name,
+			Symbol:    ticker,
+			Name:      name,
 			Quantity:  edge.Node.Quantity,
-			Price:     edge.Node.Price,
+			Price:     price,
 			Value:     edge.Node.Value,
-			CostBasis: edge.Node.CostBasis,
-			UpdatedAt: edge.Node.UpdatedAt,
+			CostBasis: edge.Node.Basis,
 		})
 	}
 

--- a/pkg/monarch/holdings.go
+++ b/pkg/monarch/holdings.go
@@ -1,0 +1,193 @@
+package monarch
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// Security represents a tradable security (stock, ETF, crypto, etc.)
+type Security struct {
+	ID           string  `json:"id"`
+	Name         string  `json:"name"`
+	Ticker       string  `json:"ticker"`
+	CurrentPrice float64 `json:"currentPrice"`
+}
+
+// CreateHoldingParams for creating a manual holding
+type CreateHoldingParams struct {
+	AccountID  string  `json:"accountId"`
+	SecurityID string  `json:"securityId"`
+	Quantity   float64 `json:"quantity"`
+}
+
+// SearchSecurities searches for securities by ticker or name.
+// The limit parameter controls the maximum number of results returned.
+func (s *accountService) SearchSecurities(ctx context.Context, query string, limit int) ([]*Security, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	gql := s.client.loadQuery("accounts/search_securities.graphql")
+
+	variables := map[string]interface{}{
+		"search":            query,
+		"limit":             limit,
+		"orderByPopularity": true,
+	}
+
+	var result struct {
+		Securities []*Security `json:"securities"`
+	}
+
+	if err := s.client.executeGraphQL(ctx, gql, variables, &result); err != nil {
+		return nil, errors.Wrap(err, "failed to search securities")
+	}
+
+	return result.Securities, nil
+}
+
+// CreateHolding creates a manual investment holding in an account.
+func (s *accountService) CreateHolding(ctx context.Context, params *CreateHoldingParams) (*Holding, error) {
+	gql := s.client.loadQuery("accounts/create_holding.graphql")
+
+	variables := map[string]interface{}{
+		"input": map[string]interface{}{
+			"accountId":  params.AccountID,
+			"securityId": params.SecurityID,
+			"quantity":   params.Quantity,
+		},
+	}
+
+	var result struct {
+		CreateManualHolding struct {
+			Holding *struct {
+				ID     string `json:"id"`
+				Ticker string `json:"ticker"`
+			} `json:"holding"`
+			Errors []struct {
+				Message string `json:"message"`
+				Code    string `json:"code"`
+			} `json:"errors"`
+		} `json:"createManualHolding"`
+	}
+
+	if err := s.client.executeGraphQL(ctx, gql, variables, &result); err != nil {
+		return nil, errors.Wrap(err, "failed to create holding")
+	}
+
+	if len(result.CreateManualHolding.Errors) > 0 {
+		return nil, &Error{
+			Code:    result.CreateManualHolding.Errors[0].Code,
+			Message: result.CreateManualHolding.Errors[0].Message,
+		}
+	}
+
+	if result.CreateManualHolding.Holding == nil {
+		return nil, errors.New("no holding returned from creation")
+	}
+
+	return &Holding{
+		ID:        result.CreateManualHolding.Holding.ID,
+		AccountID: params.AccountID,
+		Symbol:    result.CreateManualHolding.Holding.Ticker,
+		Quantity:  params.Quantity,
+	}, nil
+}
+
+// CreateHoldingByTicker looks up a security by ticker and creates a holding.
+func (s *accountService) CreateHoldingByTicker(ctx context.Context, accountID, ticker string, quantity float64) (*Holding, error) {
+	securities, err := s.SearchSecurities(ctx, ticker, 5)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to search for ticker")
+	}
+
+	if len(securities) == 0 {
+		return nil, fmt.Errorf("no security found for ticker: %s", ticker)
+	}
+
+	// Find exact ticker match
+	var securityID string
+	for _, sec := range securities {
+		if sec.Ticker == ticker {
+			securityID = sec.ID
+			break
+		}
+	}
+	if securityID == "" {
+		// Fall back to first result
+		securityID = securities[0].ID
+	}
+
+	return s.CreateHolding(ctx, &CreateHoldingParams{
+		AccountID:  accountID,
+		SecurityID: securityID,
+		Quantity:   quantity,
+	})
+}
+
+// DeleteHolding deletes a manual investment holding.
+func (s *accountService) DeleteHolding(ctx context.Context, holdingID string) error {
+	gql := s.client.loadQuery("accounts/delete_holding.graphql")
+
+	variables := map[string]interface{}{
+		"id": holdingID,
+	}
+
+	var result struct {
+		DeleteHolding struct {
+			Deleted bool `json:"deleted"`
+			Errors  []struct {
+				Message string `json:"message"`
+				Code    string `json:"code"`
+			} `json:"errors"`
+		} `json:"deleteHolding"`
+	}
+
+	if err := s.client.executeGraphQL(ctx, gql, variables, &result); err != nil {
+		return errors.Wrap(err, "failed to delete holding")
+	}
+
+	if len(result.DeleteHolding.Errors) > 0 {
+		return &Error{
+			Code:    result.DeleteHolding.Errors[0].Code,
+			Message: result.DeleteHolding.Errors[0].Message,
+		}
+	}
+
+	if !result.DeleteHolding.Deleted {
+		return errors.New("holding was not deleted")
+	}
+
+	return nil
+}
+
+// UpdateHoldingQuantity updates a holding's quantity by deleting and recreating it.
+// The Monarch API does not support direct quantity updates on holdings.
+func (s *accountService) UpdateHoldingQuantity(ctx context.Context, accountID, holdingID string, newQuantity float64) (*Holding, error) {
+	// Get the current holding to preserve the security info
+	holdings, err := s.GetHoldings(ctx, accountID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get holdings")
+	}
+
+	var targetHolding *Holding
+	for _, h := range holdings {
+		if h.ID == holdingID {
+			targetHolding = h
+			break
+		}
+	}
+
+	if targetHolding == nil {
+		return nil, fmt.Errorf("holding not found: %s", holdingID)
+	}
+
+	// Delete the old holding
+	if err := s.DeleteHolding(ctx, holdingID); err != nil {
+		return nil, errors.Wrap(err, "failed to delete old holding")
+	}
+
+	// Recreate with the new quantity using the ticker
+	return s.CreateHoldingByTicker(ctx, accountID, targetHolding.Symbol, newQuantity)
+}

--- a/pkg/monarch/holdings.go
+++ b/pkg/monarch/holdings.go
@@ -3,6 +3,7 @@ package monarch
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -106,17 +107,16 @@ func (s *accountService) CreateHoldingByTicker(ctx context.Context, accountID, t
 		return nil, fmt.Errorf("no security found for ticker: %s", ticker)
 	}
 
-	// Find exact ticker match
+	// Require exact case-insensitive ticker match
 	var securityID string
 	for _, sec := range securities {
-		if sec.Ticker == ticker {
+		if strings.EqualFold(sec.Ticker, ticker) {
 			securityID = sec.ID
 			break
 		}
 	}
 	if securityID == "" {
-		// Fall back to first result
-		securityID = securities[0].ID
+		return nil, fmt.Errorf("no exact ticker match for %q in search results", ticker)
 	}
 
 	return s.CreateHolding(ctx, &CreateHoldingParams{
@@ -162,32 +162,48 @@ func (s *accountService) DeleteHolding(ctx context.Context, holdingID string) er
 	return nil
 }
 
-// UpdateHoldingQuantity updates a holding's quantity by deleting and recreating it.
-// The Monarch API does not support direct quantity updates on holdings.
+// UpdateHoldingQuantity updates a holding's quantity via the updateHolding mutation.
 func (s *accountService) UpdateHoldingQuantity(ctx context.Context, accountID, holdingID string, newQuantity float64) (*Holding, error) {
-	// Get the current holding to preserve the security info
-	holdings, err := s.GetHoldings(ctx, accountID)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get holdings")
+	gql := s.client.loadQuery("accounts/update_holding.graphql")
+
+	variables := map[string]interface{}{
+		"input": map[string]interface{}{
+			"id":       holdingID,
+			"quantity": newQuantity,
+		},
 	}
 
-	var targetHolding *Holding
-	for _, h := range holdings {
-		if h.ID == holdingID {
-			targetHolding = h
-			break
+	var result struct {
+		UpdateHolding struct {
+			Holding *struct {
+				ID       string  `json:"id"`
+				Quantity float64 `json:"quantity"`
+			} `json:"holding"`
+			Errors []struct {
+				Message string `json:"message"`
+				Code    string `json:"code"`
+			} `json:"errors"`
+		} `json:"updateHolding"`
+	}
+
+	if err := s.client.executeGraphQL(ctx, gql, variables, &result); err != nil {
+		return nil, errors.Wrap(err, "failed to update holding")
+	}
+
+	if len(result.UpdateHolding.Errors) > 0 {
+		return nil, &Error{
+			Code:    result.UpdateHolding.Errors[0].Code,
+			Message: result.UpdateHolding.Errors[0].Message,
 		}
 	}
 
-	if targetHolding == nil {
-		return nil, fmt.Errorf("holding not found: %s", holdingID)
+	if result.UpdateHolding.Holding == nil {
+		return nil, errors.New("no holding returned from update")
 	}
 
-	// Delete the old holding
-	if err := s.DeleteHolding(ctx, holdingID); err != nil {
-		return nil, errors.Wrap(err, "failed to delete old holding")
-	}
-
-	// Recreate with the new quantity using the ticker
-	return s.CreateHoldingByTicker(ctx, accountID, targetHolding.Symbol, newQuantity)
+	return &Holding{
+		ID:        result.UpdateHolding.Holding.ID,
+		AccountID: accountID,
+		Quantity:  result.UpdateHolding.Holding.Quantity,
+	}, nil
 }

--- a/pkg/monarch/holdings_test.go
+++ b/pkg/monarch/holdings_test.go
@@ -2,6 +2,7 @@ package monarch
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/eshaffer321/monarchmoney-go/internal/graphql"
@@ -177,4 +178,205 @@ func TestAccountService_CreateHoldingByTicker_NotFound(t *testing.T) {
 	_, err := client.Accounts.CreateHoldingByTicker(context.Background(), "acc-789", "NOTREAL", 1.0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no security found")
+}
+
+func TestAccountService_SearchSecurities_DefaultLimit(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything,
+		mock.MatchedBy(func(v map[string]interface{}) bool {
+			limit, ok := v["limit"].(int)
+			return ok && limit == 10 // default when <= 0
+		}),
+		mock.Anything,
+	).Return(`{"securities": []}`, nil)
+
+	_, err := client.Accounts.SearchSecurities(context.Background(), "BTC", 0)
+	require.NoError(t, err)
+}
+
+func TestAccountService_SearchSecurities_GraphQLError(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return("", errors.New("network error"))
+
+	_, err := client.Accounts.SearchSecurities(context.Background(), "BTC", 5)
+	require.Error(t, err)
+}
+
+func TestAccountService_CreateHolding_GraphQLError(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return("", errors.New("network error"))
+
+	_, err := client.Accounts.CreateHolding(context.Background(), &CreateHoldingParams{
+		AccountID:  "acc-1",
+		SecurityID: "sec-1",
+		Quantity:   1.0,
+	})
+	require.Error(t, err)
+}
+
+func TestAccountService_DeleteHolding_GraphQLError(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return("", errors.New("network error"))
+
+	err := client.Accounts.DeleteHolding(context.Background(), "hold-1")
+	require.Error(t, err)
+}
+
+func TestAccountService_DeleteHolding_WithErrors(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	responseJSON := `{
+		"deleteHolding": {
+			"deleted": false,
+			"errors": [{"message": "not found", "code": "NOT_FOUND"}]
+		}
+	}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(responseJSON, nil)
+
+	err := client.Accounts.DeleteHolding(context.Background(), "hold-bad")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestAccountService_UpdateHoldingQuantity(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	// Call 1: GetHoldings (portfolio query format)
+	holdingsResponse := `{
+		"portfolio": {
+			"aggregateHoldings": {
+				"edges": [{
+					"node": {
+						"id": "agg-1",
+						"quantity": 1.0,
+						"basis": 50000,
+						"totalValue": 94000,
+						"holdings": [{"id": "hold-1", "name": "Bitcoin", "ticker": "BTC", "closingPrice": 94000}],
+						"security": {"id": "sec-btc", "name": "Bitcoin", "ticker": "BTC", "currentPrice": 94000}
+					}
+				}]
+			}
+		}
+	}`
+
+	// Call 2: DeleteHolding
+	deleteResponse := `{"deleteHolding": {"deleted": true, "errors": []}}`
+
+	// Call 3: SearchSecurities (from CreateHoldingByTicker)
+	searchResponse := `{"securities": [{"id": "sec-btc", "name": "Bitcoin", "ticker": "BTC", "currentPrice": 94000}]}`
+
+	// Call 4: CreateHolding
+	createResponse := `{"createManualHolding": {"holding": {"id": "hold-new", "ticker": "BTC"}, "errors": []}}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(holdingsResponse, nil).Once()
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(deleteResponse, nil).Once()
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(searchResponse, nil).Once()
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(createResponse, nil).Once()
+
+	holding, err := client.Accounts.UpdateHoldingQuantity(context.Background(), "acc-1", "hold-1", 2.5)
+	require.NoError(t, err)
+	assert.Equal(t, "hold-new", holding.ID)
+	assert.Equal(t, 2.5, holding.Quantity)
+	mockTransport.AssertExpectations(t)
+}
+
+func TestAccountService_UpdateHoldingQuantity_HoldingNotFound(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	holdingsResponse := `{
+		"portfolio": {
+			"aggregateHoldings": {"edges": []}
+		}
+	}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(holdingsResponse, nil)
+
+	_, err := client.Accounts.UpdateHoldingQuantity(context.Background(), "acc-1", "nonexistent", 2.0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "holding not found")
+}
+
+func TestAccountService_UpdateHoldingQuantity_GetHoldingsError(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return("", errors.New("API error"))
+
+	_, err := client.Accounts.UpdateHoldingQuantity(context.Background(), "acc-1", "hold-1", 2.0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get holdings")
+}
+
+func TestAccountService_UpdateHoldingQuantity_DeleteError(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	holdingsResponse := `{
+		"portfolio": {
+			"aggregateHoldings": {
+				"edges": [{
+					"node": {
+						"id": "agg-1",
+						"quantity": 1.0,
+						"basis": 50000,
+						"totalValue": 94000,
+						"holdings": [{"id": "hold-1", "name": "Bitcoin", "ticker": "BTC", "closingPrice": 94000}],
+						"security": {"id": "sec-btc", "name": "Bitcoin", "ticker": "BTC", "currentPrice": 94000}
+					}
+				}]
+			}
+		}
+	}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(holdingsResponse, nil).Once()
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return("", errors.New("delete failed")).Once()
+
+	_, err := client.Accounts.UpdateHoldingQuantity(context.Background(), "acc-1", "hold-1", 2.0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete old holding")
+}
+
+func TestAccountService_CreateHoldingByTicker_SearchError(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return("", errors.New("search failed"))
+
+	_, err := client.Accounts.CreateHoldingByTicker(context.Background(), "acc-1", "BTC", 1.0)
+	require.Error(t, err)
 }

--- a/pkg/monarch/holdings_test.go
+++ b/pkg/monarch/holdings_test.go
@@ -1,0 +1,180 @@
+package monarch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/eshaffer321/monarchmoney-go/internal/graphql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestClient(transport *MockTransport) *Client {
+	return &Client{
+		transport:   transport,
+		queryLoader: graphql.NewQueryLoader(),
+		options:     &ClientOptions{},
+		baseURL:     "https://api.test.com",
+	}
+}
+
+func TestAccountService_SearchSecurities(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	responseJSON := `{
+		"securities": [
+			{"id": "sec-123", "name": "Bitcoin", "ticker": "BTC", "currentPrice": 94200.50}
+		]
+	}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(responseJSON, nil)
+
+	securities, err := client.Accounts.SearchSecurities(context.Background(), "BTC", 5)
+	require.NoError(t, err)
+	require.Len(t, securities, 1)
+	assert.Equal(t, "sec-123", securities[0].ID)
+	assert.Equal(t, "BTC", securities[0].Ticker)
+	assert.Equal(t, "Bitcoin", securities[0].Name)
+	assert.Equal(t, 94200.50, securities[0].CurrentPrice)
+}
+
+func TestAccountService_CreateHolding(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	responseJSON := `{
+		"createManualHolding": {
+			"holding": {"id": "hold-456", "ticker": "BTC"},
+			"errors": []
+		}
+	}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(responseJSON, nil)
+
+	holding, err := client.Accounts.CreateHolding(context.Background(), &CreateHoldingParams{
+		AccountID:  "acc-789",
+		SecurityID: "sec-123",
+		Quantity:   0.5,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "hold-456", holding.ID)
+	assert.Equal(t, "BTC", holding.Symbol)
+	assert.Equal(t, "acc-789", holding.AccountID)
+	assert.Equal(t, 0.5, holding.Quantity)
+}
+
+func TestAccountService_CreateHolding_Error(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	responseJSON := `{
+		"createManualHolding": {
+			"holding": null,
+			"errors": [{"message": "invalid security", "code": "INVALID"}]
+		}
+	}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(responseJSON, nil)
+
+	_, err := client.Accounts.CreateHolding(context.Background(), &CreateHoldingParams{
+		AccountID:  "acc-789",
+		SecurityID: "bad-id",
+		Quantity:   1.0,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid security")
+}
+
+func TestAccountService_DeleteHolding(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	responseJSON := `{
+		"deleteHolding": {
+			"deleted": true,
+			"errors": []
+		}
+	}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(responseJSON, nil)
+
+	err := client.Accounts.DeleteHolding(context.Background(), "hold-456")
+	require.NoError(t, err)
+}
+
+func TestAccountService_DeleteHolding_NotDeleted(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	responseJSON := `{
+		"deleteHolding": {
+			"deleted": false,
+			"errors": []
+		}
+	}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(responseJSON, nil)
+
+	err := client.Accounts.DeleteHolding(context.Background(), "hold-456")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not deleted")
+}
+
+func TestAccountService_CreateHoldingByTicker(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	// First call: search securities
+	searchResponse := `{
+		"securities": [
+			{"id": "sec-btc", "name": "Bitcoin", "ticker": "BTC", "currentPrice": 94200.00}
+		]
+	}`
+
+	// Second call: create holding
+	createResponse := `{
+		"createManualHolding": {
+			"holding": {"id": "hold-new", "ticker": "BTC"},
+			"errors": []
+		}
+	}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(searchResponse, nil).Once()
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(createResponse, nil).Once()
+
+	holding, err := client.Accounts.CreateHoldingByTicker(context.Background(), "acc-789", "BTC", 1.5)
+	require.NoError(t, err)
+	assert.Equal(t, "hold-new", holding.ID)
+	assert.Equal(t, "BTC", holding.Symbol)
+	assert.Equal(t, 1.5, holding.Quantity)
+}
+
+func TestAccountService_CreateHoldingByTicker_NotFound(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	searchResponse := `{"securities": []}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(searchResponse, nil)
+
+	_, err := client.Accounts.CreateHoldingByTicker(context.Background(), "acc-789", "NOTREAL", 1.0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no security found")
+}

--- a/pkg/monarch/holdings_test.go
+++ b/pkg/monarch/holdings_test.go
@@ -180,6 +180,22 @@ func TestAccountService_CreateHoldingByTicker_NotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "no security found")
 }
 
+func TestAccountService_CreateHoldingByTicker_NoExactMatch(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	// Results exist but none match the exact ticker
+	searchResponse := `{"securities": [{"id": "sec-1", "name": "Bitcoin Cash", "ticker": "BCH", "currentPrice": 400}]}`
+
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(searchResponse, nil)
+
+	_, err := client.Accounts.CreateHoldingByTicker(context.Background(), "acc-789", "BTC", 1.0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no exact ticker match")
+}
+
 func TestAccountService_SearchSecurities_DefaultLimit(t *testing.T) {
 	mockTransport := new(MockTransport)
 	client := newTestClient(mockTransport)
@@ -262,111 +278,74 @@ func TestAccountService_UpdateHoldingQuantity(t *testing.T) {
 	client := newTestClient(mockTransport)
 	client.Accounts = &accountService{client: client}
 
-	// Call 1: GetHoldings (portfolio query format)
-	holdingsResponse := `{
-		"portfolio": {
-			"aggregateHoldings": {
-				"edges": [{
-					"node": {
-						"id": "agg-1",
-						"quantity": 1.0,
-						"basis": 50000,
-						"totalValue": 94000,
-						"holdings": [{"id": "hold-1", "name": "Bitcoin", "ticker": "BTC", "closingPrice": 94000}],
-						"security": {"id": "sec-btc", "name": "Bitcoin", "ticker": "BTC", "currentPrice": 94000}
-					}
-				}]
-			}
+	responseJSON := `{
+		"updateHolding": {
+			"holding": {"id": "hold-1", "quantity": 2.5},
+			"errors": []
 		}
 	}`
 
-	// Call 2: DeleteHolding
-	deleteResponse := `{"deleteHolding": {"deleted": true, "errors": []}}`
-
-	// Call 3: SearchSecurities (from CreateHoldingByTicker)
-	searchResponse := `{"securities": [{"id": "sec-btc", "name": "Bitcoin", "ticker": "BTC", "currentPrice": 94000}]}`
-
-	// Call 4: CreateHolding
-	createResponse := `{"createManualHolding": {"holding": {"id": "hold-new", "ticker": "BTC"}, "errors": []}}`
-
 	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(holdingsResponse, nil).Once()
-	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(deleteResponse, nil).Once()
-	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(searchResponse, nil).Once()
-	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(createResponse, nil).Once()
+		Return(responseJSON, nil)
 
 	holding, err := client.Accounts.UpdateHoldingQuantity(context.Background(), "acc-1", "hold-1", 2.5)
 	require.NoError(t, err)
-	assert.Equal(t, "hold-new", holding.ID)
+	assert.Equal(t, "hold-1", holding.ID)
+	assert.Equal(t, "acc-1", holding.AccountID)
 	assert.Equal(t, 2.5, holding.Quantity)
-	mockTransport.AssertExpectations(t)
 }
 
-func TestAccountService_UpdateHoldingQuantity_HoldingNotFound(t *testing.T) {
+func TestAccountService_UpdateHoldingQuantity_GraphQLError(t *testing.T) {
 	mockTransport := new(MockTransport)
 	client := newTestClient(mockTransport)
 	client.Accounts = &accountService{client: client}
 
-	holdingsResponse := `{
-		"portfolio": {
-			"aggregateHoldings": {"edges": []}
+	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return("", errors.New("network error"))
+
+	_, err := client.Accounts.UpdateHoldingQuantity(context.Background(), "acc-1", "hold-1", 2.0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update holding")
+}
+
+func TestAccountService_UpdateHoldingQuantity_MutationErrors(t *testing.T) {
+	mockTransport := new(MockTransport)
+	client := newTestClient(mockTransport)
+	client.Accounts = &accountService{client: client}
+
+	responseJSON := `{
+		"updateHolding": {
+			"holding": null,
+			"errors": [{"message": "holding not found", "code": "NOT_FOUND"}]
 		}
 	}`
 
 	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(holdingsResponse, nil)
+		Return(responseJSON, nil)
 
-	_, err := client.Accounts.UpdateHoldingQuantity(context.Background(), "acc-1", "nonexistent", 2.0)
+	_, err := client.Accounts.UpdateHoldingQuantity(context.Background(), "acc-1", "hold-bad", 2.0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "holding not found")
 }
 
-func TestAccountService_UpdateHoldingQuantity_GetHoldingsError(t *testing.T) {
+func TestAccountService_UpdateHoldingQuantity_NilHolding(t *testing.T) {
 	mockTransport := new(MockTransport)
 	client := newTestClient(mockTransport)
 	client.Accounts = &accountService{client: client}
 
-	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return("", errors.New("API error"))
-
-	_, err := client.Accounts.UpdateHoldingQuantity(context.Background(), "acc-1", "hold-1", 2.0)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to get holdings")
-}
-
-func TestAccountService_UpdateHoldingQuantity_DeleteError(t *testing.T) {
-	mockTransport := new(MockTransport)
-	client := newTestClient(mockTransport)
-	client.Accounts = &accountService{client: client}
-
-	holdingsResponse := `{
-		"portfolio": {
-			"aggregateHoldings": {
-				"edges": [{
-					"node": {
-						"id": "agg-1",
-						"quantity": 1.0,
-						"basis": 50000,
-						"totalValue": 94000,
-						"holdings": [{"id": "hold-1", "name": "Bitcoin", "ticker": "BTC", "closingPrice": 94000}],
-						"security": {"id": "sec-btc", "name": "Bitcoin", "ticker": "BTC", "currentPrice": 94000}
-					}
-				}]
-			}
+	responseJSON := `{
+		"updateHolding": {
+			"holding": null,
+			"errors": []
 		}
 	}`
 
 	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(holdingsResponse, nil).Once()
-	mockTransport.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return("", errors.New("delete failed")).Once()
+		Return(responseJSON, nil)
 
 	_, err := client.Accounts.UpdateHoldingQuantity(context.Background(), "acc-1", "hold-1", 2.0)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to delete old holding")
+	assert.Contains(t, err.Error(), "no holding returned")
 }
 
 func TestAccountService_CreateHoldingByTicker_SearchError(t *testing.T) {

--- a/pkg/monarch/interfaces.go
+++ b/pkg/monarch/interfaces.go
@@ -37,6 +37,25 @@ type AccountService interface {
 	// GetHoldings retrieves investment holdings for an account
 	GetHoldings(ctx context.Context, accountID string) ([]*Holding, error)
 
+	// SearchSecurities searches for securities by ticker or name.
+	// The limit parameter controls the maximum number of results.
+	SearchSecurities(ctx context.Context, query string, limit int) ([]*Security, error)
+
+	// CreateInvestmentsAccount creates a manual investments account with initial holdings
+	CreateInvestmentsAccount(ctx context.Context, params *CreateInvestmentsAccountParams) (*Account, error)
+
+	// CreateHolding creates a manual investment holding
+	CreateHolding(ctx context.Context, params *CreateHoldingParams) (*Holding, error)
+
+	// CreateHoldingByTicker looks up a security by ticker and creates a holding
+	CreateHoldingByTicker(ctx context.Context, accountID, ticker string, quantity float64) (*Holding, error)
+
+	// DeleteHolding deletes a manual investment holding
+	DeleteHolding(ctx context.Context, holdingID string) error
+
+	// UpdateHoldingQuantity updates a holding's quantity (delete + recreate)
+	UpdateHoldingQuantity(ctx context.Context, accountID, holdingID string, newQuantity float64) (*Holding, error)
+
 	// Refresh triggers a refresh for specified accounts
 	Refresh(ctx context.Context, accountIDs ...string) (RefreshJob, error)
 

--- a/pkg/monarch/types.go
+++ b/pkg/monarch/types.go
@@ -351,6 +351,20 @@ type CreateAccountParams struct {
 	IncludeInNetWorth bool    `json:"includeInNetWorth"`
 }
 
+// CreateInvestmentsAccountParams for creating a manual investments account with holdings.
+type CreateInvestmentsAccountParams struct {
+	Name                          string            `json:"name"`
+	Subtype                       string            `json:"subtype"`
+	ManualInvestmentsTrackingMethod string          `json:"manualInvestmentsTrackingMethod"`
+	InitialHoldings               []InitialHolding  `json:"initialHoldings"`
+}
+
+// InitialHolding represents a holding to include when creating an investments account.
+type InitialHolding struct {
+	SecurityID string  `json:"securityId"`
+	Quantity   float64 `json:"quantity"`
+}
+
 // UpdateAccountParams for updating accounts
 type UpdateAccountParams struct {
 	DisplayName                 *string  `json:"displayName,omitempty"`


### PR DESCRIPTION
## Summary
- Add `SearchSecurities(ctx, query, limit)` — searches for securities by ticker or name, with configurable result limit (defaults to 10 if `<= 0`)
- Add `CreateHolding` / `DeleteHolding` / `UpdateHoldingQuantity` for manual investment holdings
- Add `CreateHoldingByTicker` convenience method (looks up security then creates holding)
- Add `CreateInvestmentsAccount` for creating manual investment accounts with initial holdings
- Simplify `GetHoldings` query to use the account-based holdings endpoint (simpler, more reliable)
- Add `holdings_test.go` with tests for search, create, delete, and update operations

No auth or transaction changes are included — this PR is self-contained.

Split from #19 per review feedback.

## Test plan
- [ ] Existing tests pass (`go test ./...`)
- [ ] `SearchSecurities("BTC", 5)` returns bitcoin-related securities
- [ ] `CreateHoldingByTicker(accountID, "BTC", 1.5)` creates a BTC holding
- [ ] `DeleteHolding(holdingID)` removes a holding
- [ ] `UpdateHoldingQuantity(accountID, holdingID, 2.0)` updates quantity
- [ ] `CreateInvestmentsAccount` creates account with initial holdings